### PR TITLE
[feature] #22 - Swagger UI(website) 에서 jwt를 사용하여 request 요청 가능

### DIFF
--- a/src/main/java/com/dbsgapi/dbsgapi/global/configuration/SwaggerConfiguration.java
+++ b/src/main/java/com/dbsgapi/dbsgapi/global/configuration/SwaggerConfiguration.java
@@ -1,13 +1,17 @@
 package com.dbsgapi.dbsgapi.global.configuration;
 
 import com.dbsgapi.dbsgapi.global.configuration.properties.SwaggerProperty;
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.ExternalDocumentation;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
 
 @Configuration
 @RequiredArgsConstructor
@@ -16,10 +20,26 @@ public class SwaggerConfiguration {
 
     @Bean
     public OpenAPI springShopOpenAPI() {
-        return new OpenAPI().info(new Info()
+        // Security 스키마 설정
+        SecurityScheme bearerAuth = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+                .in(SecurityScheme.In.HEADER)
+                .name(HttpHeaders.AUTHORIZATION);
+
+        // Security 요청 설정
+        SecurityRequirement addSecurityItem = new SecurityRequirement();
+        addSecurityItem.addList("JWT");
+
+        // Swagger 생성
+        return new OpenAPI()
+                .info(new Info()
                         .title(swaggerProperty.getTitle())
                         .description(swaggerProperty.getDescription())
                         .version(swaggerProperty.getVersion())
-                        .license(new License().name("Apache 2.0").url("http://springdoc.org")));
+                        .license(new License().name("Apache 2.0").url("http://springdoc.org")))
+                .components(new Components().addSecuritySchemes("JWT", bearerAuth))
+                .addSecurityItem(addSecurityItem);
     }
 }


### PR DESCRIPTION
swagger ui에 새로 추가된 auth. 버튼을 통해 발급받은 jwt 를 request에 포함시킬 수 있다.

![image](https://user-images.githubusercontent.com/10378777/189953827-09792b99-c346-4ba7-bf6f-93a08a149c03.png)


이 때, 값의 처음에 `bearer `를 입력하지 않아도 된다. (오직 jwt만 지원하기 때문에)

![image](https://user-images.githubusercontent.com/10378777/189954018-2cb25f29-a597-40d0-8a33-9e27403302bb.png)


closes #22 